### PR TITLE
Style-Bert-VITS2 TTS エンジンのサポートを追加

### DIFF
--- a/config/example.stream-profile.docker.json
+++ b/config/example.stream-profile.docker.json
@@ -50,7 +50,6 @@
       "audioProfile": {
         "ttsEngine": "voicevox",
         "voicevoxUrl": "http://voicevox:50021",
-        "speakerId": 1,
         "voices": [
           {
             "emotion": "neutral",

--- a/config/example.stream-profile.local.json
+++ b/config/example.stream-profile.local.json
@@ -50,7 +50,6 @@
       "audioProfile": {
         "ttsEngine": "voicevox",
         "voicevoxUrl": "http://127.0.0.1:50021",
-        "speakerId": 1,
         "voices": [
           {
             "emotion": "neutral",

--- a/config/example.stream-profile.sbv2.json
+++ b/config/example.stream-profile.sbv2.json
@@ -1,0 +1,77 @@
+{
+  "server": {
+    "port": 4000,
+    "host": "0.0.0.0",
+    "apiKey": "replace-with-your-key"
+  },
+  "rtmp": {
+    "outputUrl": "rtmp://127.0.0.1:1936/live/main"
+  },
+  "presets": [
+    {
+      "id": "anchor-sbv2",
+      "displayName": "Anchor (Style-Bert-VITS2)",
+      "actions": [
+        { "id": "start", "path": "idle_talk.mp4" }
+      ],
+      "idleMotions": {
+        "large": [
+          { "id": "idle-large", "emotion": "neutral", "path": "idle.mp4" }
+        ],
+        "small": [
+          { "id": "idle-small", "emotion": "neutral", "path": "talk_idle.mp4" }
+        ]
+      },
+      "speechMotions": {
+        "large": [
+          { "id": "talk-large", "emotion": "neutral", "path": "talk_large.mp4" },
+          { "id": "talk-happy-large", "emotion": "happy", "path": "talk_large.mp4" }
+        ],
+        "small": [
+          { "id": "talk-small", "emotion": "neutral", "path": "talk_small.mp4" },
+          { "id": "talk-happy-small", "emotion": "happy", "path": "talk_small.mp4" }
+        ]
+      },
+      "speechTransitions": {
+        "enter": [
+          { "id": "transition-enter", "emotion": "neutral", "path": "idle_talk.mp4" },
+          { "id": "transition-enter-happy", "emotion": "happy", "path": "idle_talk.mp4" }
+        ],
+        "exit": [
+          { "id": "transition-exit", "emotion": "neutral", "path": "talk_idle.mp4" },
+          { "id": "transition-exit-happy", "emotion": "happy", "path": "talk_idle.mp4" }
+        ]
+      },
+      "audioProfile": {
+        "ttsEngine": "style-bert-vits2",
+        "sbv2Url": "http://127.0.0.1:5000",
+        "voices": [
+          {
+            "emotion": "neutral",
+            "modelId": 0,
+            "speakerId": 0,
+            "sdpRatio": 0.2,
+            "noise": 0.6,
+            "noisew": 0.8,
+            "length": 1.0,
+            "language": "JP",
+            "style": "Neutral",
+            "styleWeight": 1.0
+          },
+          {
+            "emotion": "happy",
+            "modelId": 0,
+            "speakerId": 0,
+            "sdpRatio": 0.2,
+            "noise": 0.6,
+            "noisew": 0.8,
+            "length": 1.0,
+            "language": "JP",
+            "style": "Happy",
+            "styleWeight": 1.2
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/src/app.ts
+++ b/src/app.ts
@@ -4,6 +4,7 @@ import { loadConfig, type ResolvedConfig } from './config/loader'
 import { MediaPipeline } from './services/media-pipeline'
 import { ClipPlanner } from './services/clip-planner'
 import { VoicevoxClient } from './services/voicevox'
+import { StyleBertVits2Client } from './services/style-bert-vits2'
 import { GenerationService } from './services/generation.service'
 import { createGenerationRouter } from './api/generation.controller'
 import { createDocsRouter } from './api/docs'
@@ -24,11 +25,13 @@ export const createApp = async (options: CreateAppOptions = {}) => {
 
   await clipPlanner.validateMotionSpecs(config.presets)
   const voicevox = new VoicevoxClient()
+  const sbv2 = new StyleBertVits2Client()
   const generationService = new GenerationService({
     config,
     clipPlanner,
     mediaPipeline,
     voicevox,
+    sbv2,
   })
 
   const app = express()

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -25,7 +25,8 @@ export const transitionMotionSchema = z.object({
 })
 const transitionCollectionSchema = z.union([transitionMotionSchema, z.array(transitionMotionSchema).min(1)])
 
-const synthesisParamsSchema = z.object({
+// VOICEVOX用パラメータスキーマ
+const voicevoxSynthesisParamsSchema = z.object({
   speedScale: z.number().positive().optional(),
   pitchScale: z.number().optional(),
   intonationScale: z.number().nonnegative().optional(),
@@ -34,17 +35,52 @@ const synthesisParamsSchema = z.object({
   outputStereo: z.boolean().optional(),
 })
 
-const voicevoxVoiceSchema = synthesisParamsSchema.extend({
+const voicevoxVoiceSchema = voicevoxSynthesisParamsSchema.extend({
   emotion: z.string().min(1).default('neutral'),
   speakerId: z.number().int().nonnegative(),
 })
 
-export const audioProfileSchema = synthesisParamsSchema.extend({
+const voicevoxAudioProfileSchema = z.object({
   ttsEngine: z.literal('voicevox'),
   voicevoxUrl: z.string().min(1),
-  speakerId: z.number().int().nonnegative().default(1),
   voices: z.array(voicevoxVoiceSchema).optional(),
 })
+
+// Style-Bert-VITS2用パラメータスキーマ
+const sbv2SynthesisParamsSchema = z.object({
+  sdpRatio: z.number().min(0).max(1).optional(),
+  noise: z.number().min(0).max(1).optional(),
+  noisew: z.number().min(0).max(1).optional(),
+  length: z.number().positive().optional(),
+  language: z.string().optional(),
+  style: z.string().optional(),
+  styleWeight: z.number().optional(),
+  assistText: z.string().optional(),
+  assistTextWeight: z.number().optional(),
+  autoSplit: z.boolean().optional(),
+  splitInterval: z.number().nonnegative().optional(),
+  referenceAudioPath: z.string().optional(),
+})
+
+const sbv2VoiceSchema = sbv2SynthesisParamsSchema.extend({
+  emotion: z.string().min(1).default('neutral'),
+  modelId: z.number().int().nonnegative().optional(),
+  modelName: z.string().optional(),
+  speakerId: z.number().int().nonnegative().optional(),
+  speakerName: z.string().optional(),
+})
+
+const sbv2AudioProfileSchema = z.object({
+  ttsEngine: z.literal('style-bert-vits2'),
+  sbv2Url: z.string().min(1),
+  voices: z.array(sbv2VoiceSchema).optional(),
+})
+
+// 統合audioProfileスキーマ
+export const audioProfileSchema = z.discriminatedUnion('ttsEngine', [
+  voicevoxAudioProfileSchema,
+  sbv2AudioProfileSchema,
+])
 
 // STT設定スキーマ（トップレベル）- OpenAI互換API
 export const sttConfigSchema = z.object({

--- a/src/services/style-bert-vits2.ts
+++ b/src/services/style-bert-vits2.ts
@@ -1,0 +1,135 @@
+import { promises as fs } from 'node:fs'
+import { fetch } from 'undici'
+
+export interface StyleBertVits2SynthesisParameters {
+  sdpRatio?: number
+  noise?: number
+  noisew?: number
+  length?: number
+  language?: string
+  style?: string
+  styleWeight?: number
+  assistText?: string
+  assistTextWeight?: number
+  autoSplit?: boolean
+  splitInterval?: number
+  referenceAudioPath?: string
+}
+
+export interface StyleBertVits2Config {
+  endpoint?: string
+}
+
+export interface StyleBertVits2VoiceOptions extends StyleBertVits2SynthesisParameters {
+  modelId?: number
+  modelName?: string
+  speakerId?: number
+  speakerName?: string
+}
+
+export interface StyleBertVits2SynthesizeOptions {
+  endpoint?: string
+}
+
+export class StyleBertVits2Client {
+  private readonly defaultEndpoint?: string
+
+  constructor(config: StyleBertVits2Config = {}) {
+    this.defaultEndpoint = config.endpoint?.replace(/\/+$/, '')
+  }
+
+  async synthesize(
+    text: string,
+    outputPath: string,
+    voice: StyleBertVits2VoiceOptions,
+    options?: StyleBertVits2SynthesizeOptions
+  ): Promise<string> {
+    const normalizedText = text.trim()
+    if (!normalizedText) {
+      throw new Error('音声合成テキストが空です')
+    }
+    const endpoint = this.resolveEndpoint(options?.endpoint)
+
+    const queryParams = new URLSearchParams()
+    queryParams.set('text', normalizedText)
+
+    // モデル指定
+    if (voice.modelId !== undefined) {
+      queryParams.set('model_id', String(voice.modelId))
+    }
+    if (voice.modelName) {
+      queryParams.set('model_name', voice.modelName)
+    }
+
+    // スピーカー指定
+    if (voice.speakerId !== undefined) {
+      queryParams.set('speaker_id', String(voice.speakerId))
+    }
+    if (voice.speakerName) {
+      queryParams.set('speaker_name', voice.speakerName)
+    }
+
+    // 音声制御パラメータ
+    if (voice.sdpRatio !== undefined) {
+      queryParams.set('sdp_ratio', String(voice.sdpRatio))
+    }
+    if (voice.noise !== undefined) {
+      queryParams.set('noise', String(voice.noise))
+    }
+    if (voice.noisew !== undefined) {
+      queryParams.set('noisew', String(voice.noisew))
+    }
+    if (voice.length !== undefined) {
+      queryParams.set('length', String(voice.length))
+    }
+    if (voice.language) {
+      queryParams.set('language', voice.language)
+    }
+
+    // スタイル関連パラメータ
+    if (voice.style) {
+      queryParams.set('style', voice.style)
+    }
+    if (voice.styleWeight !== undefined) {
+      queryParams.set('style_weight', String(voice.styleWeight))
+    }
+    if (voice.assistText) {
+      queryParams.set('assist_text', voice.assistText)
+    }
+    if (voice.assistTextWeight !== undefined) {
+      queryParams.set('assist_text_weight', String(voice.assistTextWeight))
+    }
+
+    // その他のパラメータ
+    if (voice.autoSplit !== undefined) {
+      queryParams.set('auto_split', String(voice.autoSplit))
+    }
+    if (voice.splitInterval !== undefined) {
+      queryParams.set('split_interval', String(voice.splitInterval))
+    }
+    if (voice.referenceAudioPath) {
+      queryParams.set('reference_audio_path', voice.referenceAudioPath)
+    }
+
+    const response = await fetch(`${endpoint}/voice?${queryParams.toString()}`, {
+      method: 'GET',
+    })
+
+    if (!response.ok) {
+      const message = await response.text().catch(() => '')
+      throw new Error(`Style-Bert-VITS2 音声合成に失敗しました (${response.status}): ${message}`)
+    }
+
+    const buffer = Buffer.from(await response.arrayBuffer())
+    await fs.writeFile(outputPath, buffer)
+    return outputPath
+  }
+
+  private resolveEndpoint(override?: string): string {
+    const endpoint = override ?? this.defaultEndpoint
+    if (!endpoint) {
+      throw new Error('Style-Bert-VITS2 endpoint が設定されていません')
+    }
+    return endpoint.replace(/\/+$/, '')
+  }
+}

--- a/tests/factories/config.ts
+++ b/tests/factories/config.ts
@@ -1,7 +1,7 @@
 import path from 'node:path'
 import type {
   ResolvedAction,
-  ResolvedAudioProfile,
+  ResolvedVoicevoxAudioProfile,
   ResolvedPreset,
   ResolvedConfig,
   ResolvedIdleMotion,
@@ -72,19 +72,9 @@ const baseTransitions: ResolvedSpeechTransitions = {
   ],
 }
 
-const baseAudioProfile: ResolvedAudioProfile = {
+const baseAudioProfile: ResolvedVoicevoxAudioProfile = {
   ttsEngine: 'voicevox',
   voicevoxUrl: 'http://127.0.0.1:50021',
-  defaultVoice: {
-    emotion: 'neutral',
-    speakerId: 1,
-    speedScale: 1,
-    pitchScale: 0,
-    intonationScale: 1,
-    volumeScale: 1,
-    outputSamplingRate: 24000,
-    outputStereo: false,
-  },
   voices: [
     {
       emotion: 'neutral',
@@ -121,7 +111,6 @@ const createPreset = (): ResolvedPreset => {
     },
     audioProfile: {
       ...baseAudioProfile,
-      defaultVoice: { ...baseAudioProfile.defaultVoice },
       voices: baseAudioProfile.voices.map((voice) => ({ ...voice })),
     },
   }

--- a/tests/services/generation.service.audio.test.ts
+++ b/tests/services/generation.service.audio.test.ts
@@ -83,6 +83,7 @@ function createMockPreset(): ResolvedPreset {
   return {
     id: 'test-preset',
     audioProfile: {
+      ttsEngine: 'voicevox',
       voicevoxUrl: 'http://localhost:50021',
       defaultVoice: { speakerId: 1, emotion: 'neutral' },
       voices: [{ speakerId: 1, emotion: 'neutral' }],
@@ -113,6 +114,9 @@ function createMockDeps(config: ResolvedConfig) {
     },
     voicevox: {
       synthesize: mocks.synthesize,
+    },
+    sbv2: {
+      synthesize: vi.fn(),
     },
   }
 }

--- a/tests/services/generation.service.audio.test.ts
+++ b/tests/services/generation.service.audio.test.ts
@@ -85,7 +85,6 @@ function createMockPreset(): ResolvedPreset {
     audioProfile: {
       ttsEngine: 'voicevox',
       voicevoxUrl: 'http://localhost:50021',
-      defaultVoice: { speakerId: 1, emotion: 'neutral' },
       voices: [{ speakerId: 1, emotion: 'neutral' }],
     },
     actionsMap: new Map(),

--- a/tests/services/style-bert-vits2.test.ts
+++ b/tests/services/style-bert-vits2.test.ts
@@ -1,0 +1,155 @@
+import { promises as fs } from 'node:fs'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { StyleBertVits2Client } from '../../src/services/style-bert-vits2'
+import { fetch as undiciFetch } from 'undici'
+
+vi.mock('undici', () => ({
+  fetch: vi.fn(),
+}))
+
+const fetchMock = vi.mocked(undiciFetch)
+
+const createResponse = (options: {
+  ok?: boolean
+  status?: number
+  text?: string
+  buffer?: ArrayBuffer
+  contentType?: string
+}) => ({
+  ok: options.ok ?? true,
+  status: options.status ?? 200,
+  text: async () => options.text ?? '',
+  arrayBuffer: async () => options.buffer ?? new ArrayBuffer(0),
+  headers: {
+    get: (name: string) => (name.toLowerCase() === 'content-type' ? options.contentType ?? 'audio/wav' : null),
+  },
+})
+
+describe('StyleBertVits2Client', () => {
+  beforeEach(() => {
+    vi.spyOn(fs, 'writeFile').mockResolvedValue()
+    fetchMock.mockReset()
+  })
+
+  it('rejects empty text inputs', async () => {
+    const client = new StyleBertVits2Client({ endpoint: 'http://localhost:5000' })
+    await expect(client.synthesize('   ', '/tmp/out.wav', {})).rejects.toThrow('音声合成テキストが空です')
+  })
+
+  it('raises descriptive error when synthesis fails', async () => {
+    fetchMock.mockResolvedValueOnce(
+      createResponse({ ok: false, status: 500, text: 'engine error' })
+    )
+    const client = new StyleBertVits2Client({ endpoint: 'http://localhost:5000' })
+
+    await expect(client.synthesize('こんにちは', '/tmp/out.wav', {})).rejects.toThrow(
+      'Style-Bert-VITS2 音声合成に失敗しました (500): engine error'
+    )
+  })
+
+  it('writes synthesized audio to the provided path on success', async () => {
+    fetchMock.mockResolvedValueOnce(
+      createResponse({
+        arrayBuffer: new ArrayBuffer(8),
+        contentType: 'audio/wav',
+      })
+    )
+    const client = new StyleBertVits2Client({ endpoint: 'http://localhost:5000' })
+
+    await client.synthesize('こんにちは', '/tmp/out.wav', {})
+
+    expect(fs.writeFile).toHaveBeenCalledWith('/tmp/out.wav', expect.any(Buffer))
+  })
+
+  it('includes model_id and speaker_id in query params when specified', async () => {
+    fetchMock.mockResolvedValueOnce(createResponse({ arrayBuffer: new ArrayBuffer(4) }))
+    const client = new StyleBertVits2Client({ endpoint: 'http://localhost:5000' })
+
+    await client.synthesize('テスト', '/tmp/out.wav', { modelId: 0, speakerId: 1 })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const url = fetchMock.mock.calls[0][0] as string
+    expect(url).toContain('model_id=0')
+    expect(url).toContain('speaker_id=1')
+  })
+
+  it('includes model_name and speaker_name in query params when specified', async () => {
+    fetchMock.mockResolvedValueOnce(createResponse({ arrayBuffer: new ArrayBuffer(4) }))
+    const client = new StyleBertVits2Client({ endpoint: 'http://localhost:5000' })
+
+    await client.synthesize('テスト', '/tmp/out.wav', { modelName: 'test-model', speakerName: 'speaker-a' })
+
+    const url = fetchMock.mock.calls[0][0] as string
+    expect(url).toContain('model_name=test-model')
+    expect(url).toContain('speaker_name=speaker-a')
+  })
+
+  it('includes synthesis parameters in query', async () => {
+    fetchMock.mockResolvedValueOnce(createResponse({ arrayBuffer: new ArrayBuffer(4) }))
+    const client = new StyleBertVits2Client({ endpoint: 'http://localhost:5000' })
+
+    await client.synthesize('テスト', '/tmp/out.wav', {
+      sdpRatio: 0.5,
+      noise: 0.6,
+      noisew: 0.7,
+      length: 1.2,
+      language: 'JP',
+    })
+
+    const url = fetchMock.mock.calls[0][0] as string
+    expect(url).toContain('sdp_ratio=0.5')
+    expect(url).toContain('noise=0.6')
+    expect(url).toContain('noisew=0.7')
+    expect(url).toContain('length=1.2')
+    expect(url).toContain('language=JP')
+  })
+
+  it('includes style parameters in query', async () => {
+    fetchMock.mockResolvedValueOnce(createResponse({ arrayBuffer: new ArrayBuffer(4) }))
+    const client = new StyleBertVits2Client({ endpoint: 'http://localhost:5000' })
+
+    await client.synthesize('テスト', '/tmp/out.wav', {
+      style: 'happy',
+      styleWeight: 1.5,
+      assistText: '嬉しい',
+      assistTextWeight: 0.8,
+    })
+
+    const url = fetchMock.mock.calls[0][0] as string
+    expect(url).toContain('style=happy')
+    expect(url).toContain('style_weight=1.5')
+    expect(url).toContain(encodeURIComponent('嬉しい'))
+    expect(url).toContain('assist_text_weight=0.8')
+  })
+
+  it('includes auto_split and split_interval in query', async () => {
+    fetchMock.mockResolvedValueOnce(createResponse({ arrayBuffer: new ArrayBuffer(4) }))
+    const client = new StyleBertVits2Client({ endpoint: 'http://localhost:5000' })
+
+    await client.synthesize('テスト', '/tmp/out.wav', {
+      autoSplit: true,
+      splitInterval: 0.5,
+    })
+
+    const url = fetchMock.mock.calls[0][0] as string
+    expect(url).toContain('auto_split=true')
+    expect(url).toContain('split_interval=0.5')
+  })
+
+  it('uses override endpoint when provided', async () => {
+    fetchMock.mockResolvedValueOnce(createResponse({ arrayBuffer: new ArrayBuffer(4) }))
+    const client = new StyleBertVits2Client({ endpoint: 'http://localhost:5000' })
+
+    await client.synthesize('テスト', '/tmp/out.wav', {}, { endpoint: 'http://other:6000' })
+
+    const url = fetchMock.mock.calls[0][0] as string
+    expect(url).toContain('http://other:6000/voice')
+  })
+
+  it('throws error when endpoint is not configured', async () => {
+    const client = new StyleBertVits2Client()
+    await expect(client.synthesize('テスト', '/tmp/out.wav', {})).rejects.toThrow(
+      'Style-Bert-VITS2 endpoint が設定されていません'
+    )
+  })
+})


### PR DESCRIPTION
- Style-Bert-VITS2 クライアント実装 (src/services/style-bert-vits2.ts)
- audioProfile の設計を簡素化: ルートレベルのデフォルト設定を削除し、voices 配列に全設定を集約
- ttsEngine で voicevox / style-bert-vits2 を切り替え可能に
- voices が空の場合はエラーを返すように変更
- サンプル設定ファイル追加 (config/example.stream-profile.sbv2.json)
- README に TTS エンジン設定のドキュメントを追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * Style-Bert-VITS2 を追加し、VOICEVOX と併せて複数のTTSエンジンを選択可能に。

* **ドキュメント**
  * README を拡張し、両エンジンの設定例／パラメータ説明と起動手順を追加。

* **チューニング**
  * 音声設定の構造を整理（音声ごとの設定に統一、トップレベルの既定スピーカー削除）。

* **テスト**
  * SBV2 クライアントの単体テストと既存テストの補正を追加。

* **改善**
  * 実行時のメディア不一致に対するチェックと警告を追加。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->