### PR TITLE
fix: OWNER_PATを使用してCIワークフローをトリガー可能にする

### DIFF
--- a/.github/workflows/version-bump.yaml
+++ b/.github/workflows/version-bump.yaml
@@ -29,6 +29,7 @@ jobs:
         with:
           ref: ${{ inputs.base_branch }}
           fetch-depth: 0
+          token: ${{ secrets.OWNER_PAT }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -56,7 +57,7 @@ jobs:
 
       - name: Create Pull Request
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.OWNER_PAT }}
         run: |
           gh pr create \
             --base ${{ inputs.base_branch }} \


### PR DESCRIPTION
## Summary
- Version BumpワークフローでOWNER_PATを使用するように変更
- GITHUB_TOKENで作成されたイベントは他のワークフローをトリガーしないため、PATを使用することでCIが自動実行されるようになる

## 必要な設定
1. リポジトリのSecretsに `OWNER_PAT` を追加
   - 権限: Contents (Read and write), Pull requests (Read and write)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * ワークフロー認証の設定を更新しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->